### PR TITLE
fix build warning

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       # This step uses the `actions/setup-java` action to configure the Eclipse Temurin (Java) 17 JDK by Eclipse Adoptium.
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'
@@ -76,24 +76,6 @@ jobs:
           path: aggregation-service/target/surefire-reports/*.xml
           reporter: java-junit
           fail-on-error: true
-      - name: Generate build number
-        id: buildnumber
-        uses: einaregilsson/build-number@v3
-        with:
-          token: ${{secrets.github_token}}
-      # Now you can pass ${{ steps.buildnumber.outputs.build_number }} to the next steps.
-      - name: Another step as an example
-        uses: actions/hello-world-docker-action@v1
-        with:
-          who-to-greet: ${{ steps.buildnumber.outputs.build_number }}
-      - name: Output Run ID
-        run: echo ${{ github.run_id }}
-      - name: Output Run Number
-        run: echo ${{ github.run_number }}
-      - name: Output Run Attempt
-        run: echo ${{ github.run_attempt }}
-
-
       - name: "docker compose down"
         run: docker compose down
 #      - name: "Wait for docker down"
@@ -111,3 +93,22 @@ jobs:
           path: converter-service/target/surefire-reports/*.xml
           reporter: java-junit
           fail-on-error: true
+
+
+      - name: Generate build number
+        id: buildnumber
+        uses: einaregilsson/build-number@v3
+        with:
+          token: ${{secrets.github_token}}
+
+      # Now you can pass ${{ steps.buildnumber.outputs.build_number }} to the next steps.
+      - name: Another step as an example
+        uses: actions/hello-world-docker-action@v1
+        with:
+          who-to-greet: ${{ steps.buildnumber.outputs.build_number }}
+      - name: Output Run ID
+        run: echo ${{ github.run_id }}
+      - name: Output Run Number
+        run: echo ${{ github.run_number }}
+      - name: Output Run Attempt
+        run: echo ${{ github.run_attempt }}


### PR DESCRIPTION
build
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-java@v3, einaregilsson/build-number@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.